### PR TITLE
fix(ton): improve payload processing functions

### DIFF
--- a/.changeset/large-zebras-learn.md
+++ b/.changeset/large-zebras-learn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-ton": patch
+---
+
+Improve TON payload processing functions

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/txn.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/txn.unit.test.ts
@@ -1,9 +1,16 @@
 import { encodeOperationId } from "@ledgerhq/coin-framework/lib/operation";
 import BigNumber from "bignumber.js";
 // eslint-disable-next-line no-restricted-imports
-import { flatMap } from "lodash";
+import { Builder, Slice } from "@ton/core";
+import flatMap from "lodash/flatMap";
 import { TonJettonTransfer, TonTransaction } from "../../bridge/bridgeHelpers/api.types";
-import { mapJettonTxToOps, mapTxToOps } from "../../bridge/bridgeHelpers/txn";
+import {
+  dataToSlice,
+  decodeForwardPayload,
+  loadSnakeBytes,
+  mapJettonTxToOps,
+  mapTxToOps,
+} from "../../bridge/bridgeHelpers/txn";
 import {
   jettonTransferResponse,
   mockAccountId,
@@ -13,7 +20,7 @@ import {
 
 describe("Transaction functions", () => {
   describe("mapTxToOps", () => {
-    it.skip("should map an IN ton transaction without total_fees to a ledger operation", async () => {
+    it("should map an IN failed ton transaction without total_fees to a ledger operation", async () => {
       const { now, lt, hash, in_msg, total_fees, mc_block_seqno } =
         tonTransactionResponse.transactions[0];
 
@@ -30,20 +37,21 @@ describe("Transaction functions", () => {
           date: new Date(now * 1000), // now is defined in seconds
           extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
           fee: BigNumber(total_fees),
-          hasFailed: false,
+          hasFailed: true,
           hash: in_msg?.hash,
           id: encodeOperationId(mockAccountId, in_msg?.hash ?? "", "IN"),
           recipients: [in_msg?.destination],
           senders: ["EQCVnqqL0OOiZi2BQnjVGm-ZeUYgfUhHgAi-vn9F8-94HwrH"],
           type: "IN",
           value: BigNumber(in_msg?.value ?? 0),
+          subOperations: undefined,
         },
       ]);
     });
 
-    it.skip("should map an IN ton transaction with total_fees to a ledger operation", async () => {
+    it("should map an IN ton transaction with total_fees to a ledger operation", async () => {
       const transactions = [{ ...tonTransactionResponse.transactions[0], total_fees: "15" }];
-      const { now, lt, hash, in_msg, total_fees, mc_block_seqno, account } = transactions[0];
+      const { now, lt, hash, in_msg, total_fees, mc_block_seqno } = transactions[0];
 
       const finalOperation = flatMap(
         transactions,
@@ -52,39 +60,41 @@ describe("Transaction functions", () => {
 
       expect(finalOperation).toEqual([
         {
-          id: encodeOperationId(mockAccountId, in_msg?.hash ?? "", "NONE"),
-          hash: in_msg?.hash,
-          type: "NONE",
-          value: BigNumber(total_fees),
-          fee: BigNumber(0),
-          blockHash: null,
-          blockHeight: mc_block_seqno,
-          hasFailed: false,
-          accountId: mockAccountId,
-          senders: [account],
-          recipients: [],
-          date: new Date(now * 1000), // now is defined in seconds
-          extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
-        },
-        {
           accountId: mockAccountId,
           blockHash: null,
           blockHeight: mc_block_seqno,
           date: new Date(now * 1000), // now is defined in seconds
           extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
           fee: BigNumber(total_fees),
-          hasFailed: false,
+          hasFailed: true,
           hash: in_msg?.hash,
           id: encodeOperationId(mockAccountId, in_msg?.hash ?? "", "IN"),
           recipients: [in_msg?.destination],
           senders: ["EQCVnqqL0OOiZi2BQnjVGm-ZeUYgfUhHgAi-vn9F8-94HwrH"],
           type: "IN",
           value: BigNumber(in_msg?.value ?? 0),
+          subOperations: [
+            {
+              id: encodeOperationId(mockAccountId, in_msg?.hash ?? "", "NONE"),
+              hash: in_msg?.hash,
+              type: "NONE",
+              value: BigNumber(total_fees),
+              fee: BigNumber(0),
+              blockHeight: mc_block_seqno,
+              blockHash: null,
+              hasFailed: true,
+              accountId: mockAccountId,
+              senders: [mockAddress],
+              recipients: [],
+              date: new Date(now * 1000),
+              extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
+            },
+          ],
         },
       ]);
     });
 
-    it.skip("should map an OUT ton transaction to a ledger operation", async () => {
+    it("should map a failed OUT ton transaction to a ledger operation", async () => {
       // The IN transaction will be used as OUT transaction and it will be adjusted
       const transactions: TonTransaction[] = [
         {
@@ -97,7 +107,7 @@ describe("Transaction functions", () => {
           { ...tonTransactionResponse.transactions[0].in_msg, source: transactions[0].account },
         ];
       }
-      const { now, lt, hash, out_msgs, total_fees, mc_block_seqno, account } = transactions[0];
+      const { now, lt, hash, out_msgs, total_fees, mc_block_seqno } = transactions[0];
 
       const finalOperation = flatMap(
         transactions,
@@ -106,16 +116,16 @@ describe("Transaction functions", () => {
 
       expect(finalOperation).toEqual([
         {
-          id: encodeOperationId(mockAccountId, hash ?? "", "OUT"),
+          id: encodeOperationId(mockAccountId, hash, "OUT"),
           hash: out_msgs?.[0].hash,
           type: "OUT",
-          value: BigNumber(out_msgs[0].value ?? 0).plus(BigNumber(total_fees)),
+          value: BigNumber(out_msgs?.[0].value ?? 0),
           fee: BigNumber(total_fees),
           blockHeight: mc_block_seqno,
           blockHash: null,
-          hasFailed: false,
+          hasFailed: true,
           accountId: mockAccountId,
-          senders: [account],
+          senders: [transactions[0].account],
           recipients: ["EQDzd8aeBOU-jqYw_ZSuZjceI5p-F4b7HMprAsUJAtRPbJfg"],
           date: new Date(now * 1000), // now is defined in seconds
           extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
@@ -197,6 +207,174 @@ describe("Transaction functions", () => {
           },
         },
       ]);
+    });
+  });
+});
+
+describe("TON Payload Processing Functions", () => {
+  describe("dataToSlice", () => {
+    it("should convert base64 string to Slice when it's a valid BOC", () => {
+      // Create a Cell from a string and convert to BOC
+      const cell = new Builder().storeUint(123, 32).endCell();
+      const bocBase64 = cell.toBoc().toString("base64");
+
+      const result = dataToSlice(bocBase64);
+
+      expect(result).toBeInstanceOf(Slice);
+      expect(result?.loadUint(32)).toBe(123);
+    });
+
+    it("should fallback to BitString when the data is not a valid BOC", () => {
+      const invalidBocBase64 = "aW52YWxpZCB0b24gZGF0YQ=="; // "invalid ton data"
+
+      const result = dataToSlice(invalidBocBase64);
+
+      expect(result).toBeInstanceOf(Slice);
+    });
+
+    it("should return undefined for non-string input", () => {
+      // @ts-expect-error - Testing invalid input
+      const result = dataToSlice(null);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("loadSnakeBytes", () => {
+    it("should load bytes from a simple slice without refs", () => {
+      const cell = new Builder().storeBuffer(Buffer.from("Slice", "utf-8")).endCell();
+      const slice = cell.beginParse();
+
+      const result = loadSnakeBytes(slice);
+
+      expect(result.toString("utf-8")).toBe("Slice");
+    });
+
+    it("should load bytes from a slice with refs (snake structure)", () => {
+      // Create a chain of cells (snake structure)
+      const cell2 = new Builder().storeBuffer(Buffer.from(" Data", "utf-8")).endCell();
+      const cell1 = new Builder()
+        .storeBuffer(Buffer.from("Slice", "utf-8"))
+        .storeRef(cell2)
+        .endCell();
+
+      const slice = cell1.beginParse();
+
+      const result = loadSnakeBytes(slice);
+
+      expect(result.toString("utf-8")).toBe("Slice Data");
+    });
+
+    it("should handle empty slice", () => {
+      const cell = new Builder().endCell();
+      const slice = cell.beginParse();
+
+      const result = loadSnakeBytes(slice);
+
+      expect(result.length).toBe(0);
+    });
+
+    it("should handle slice with multiple refs in chain", () => {
+      // Create a longer chain of cells (snake structure)
+      const cell3 = new Builder().storeBuffer(Buffer.from("Part3", "utf-8")).endCell();
+      const cell2 = new Builder()
+        .storeBuffer(Buffer.from("Part2", "utf-8"))
+        .storeRef(cell3)
+        .endCell();
+      const cell1 = new Builder()
+        .storeBuffer(Buffer.from("Part1", "utf-8"))
+        .storeRef(cell2)
+        .endCell();
+
+      const slice = cell1.beginParse();
+
+      const result = loadSnakeBytes(slice);
+
+      expect(result.toString("utf-8")).toBe("Part1Part2Part3");
+    });
+  });
+
+  describe("decodeForwardPayload", () => {
+    it("should return empty string for null payload", () => {
+      const result = decodeForwardPayload(null);
+
+      expect(result).toBe("");
+    });
+
+    it("should decode a valid payload with opcode 0 containing text", () => {
+      // Create a cell with opcode 0 followed by a text string
+      const cell = new Builder()
+        .storeUint(0, 32) // opcode 0
+        .storeBuffer(Buffer.from("This is the comment", "utf-8"))
+        .endCell();
+      const bocBase64 = cell.toBoc().toString("base64");
+
+      const result = decodeForwardPayload(bocBase64);
+
+      expect(result).toBe("This is the comment");
+    });
+
+    it("should return empty string for payloads with non-zero opcode", () => {
+      // Create a cell with opcode 1 followed by some data
+      const cell = new Builder()
+        .storeUint(1, 32) // non-zero opcode
+        .storeBuffer(Buffer.from("Should be ignored", "utf-8"))
+        .endCell();
+      const bocBase64 = cell.toBoc().toString("base64");
+
+      const result = decodeForwardPayload(bocBase64);
+
+      expect(result).toBe("");
+    });
+
+    it("should handle payload with unicode characters", () => {
+      // Create a cell with opcode 0 followed by a text with unicode
+      const cell = new Builder()
+        .storeUint(0, 32) // opcode 0
+        .storeBuffer(Buffer.from("Unicode: 你好, мир, 🚀", "utf-8"))
+        .endCell();
+      const bocBase64 = cell.toBoc().toString("base64");
+
+      const result = decodeForwardPayload(bocBase64);
+
+      expect(result).toBe("Unicode: 你好, мир, 🚀");
+    });
+
+    it("should handle snake format payloads correctly", () => {
+      // Create a chain of cells with opcode 0 followed by a long message
+      const cell2 = new Builder()
+        .storeBuffer(Buffer.from(" would need multiple cells to store.", "utf-8"))
+        .endCell();
+      const cell1 = new Builder()
+        .storeUint(0, 32) // opcode 0
+        .storeBuffer(Buffer.from("This is a very long message that", "utf-8"))
+        .storeRef(cell2)
+        .endCell();
+
+      const bocBase64 = cell1.toBoc().toString("base64");
+
+      const result = decodeForwardPayload(bocBase64);
+
+      expect(result).toBe("This is a very long message that would need multiple cells to store.");
+    });
+
+    it("should handle invalid payloads gracefully by returning empty string", () => {
+      // Create an invalid base64 string
+      const invalidBase64 = "!@#$%^&*()";
+
+      const result = decodeForwardPayload(invalidBase64);
+
+      expect(result).toBe("");
+    });
+
+    it("should handle valid base64 but invalid BOC payloads", () => {
+      // Valid base64 but not a valid BOC
+      const validBase64NotBoc = "aW52YWxpZCB0b24gZGF0YQ=="; // "invalid ton data" in base64
+
+      const result = decodeForwardPayload(validBase64NotBoc);
+
+      // Should return empty string as it's not a valid Cell
+      expect(result).toBe("");
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This pull request addresses an issue where users who set up their TON accounts using MyTonWallet with a Ledger device are unable to add any TON account to LL, receiving an "Accounts not found" error.

The solution proposed here involves improving the transfer payload decoding process. This enhancement ensures that the data exchanged between systems is correctly interpreted, allowing users to successfully add and manage their TON accounts in LL.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
